### PR TITLE
Fix issue with redirecting /index.html to /

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -72,7 +72,7 @@ module.exports = {
         mergeStyleHashes: false,
         directives: {
           'style-src': "'self' 'unsafe-inline'",
-          'script-src': "'self' https://gc.zgo.at",
+          'script-src': "'self' 'unsafe-inline' https://gc.zgo.at",
           'default-src': "'none'",
           'manifest-src': "'self'",
           'img-src': "'self' data: https://alephium.goatcounter.com"


### PR DESCRIPTION
The issue seems to appear due to our strict CSP. Here's more info: https://github.com/gatsbyjs/gatsby/discussions/10890#discussioncomment-1653001

Since we have a plain static site I don't think there's any problem degrading our CSP. However, I have to admit that Gatsby is not very CSP friendly, as the discussions in the issue I link to show...