### PR TITLE
Remove href attribute from links that open modals

### DIFF
--- a/src/components/SimpleLink.tsx
+++ b/src/components/SimpleLink.tsx
@@ -3,14 +3,14 @@ import styled from 'styled-components'
 
 export interface SimpleLinkProps {
   className?: string
-  url?: string
+  url?: string | undefined
   text?: string
   newTab?: boolean
   color?: string
   openModal?: (x: boolean) => void
 }
 
-let SimpleLink: FC<SimpleLinkProps> = ({ className, children, url = '', newTab, text, openModal }) => {
+let SimpleLink: FC<SimpleLinkProps> = ({ className, children, url, newTab, text, openModal }) => {
   const handleOnClick = (event: MouseEvent) => {
     if (openModal) {
       event.preventDefault()

--- a/src/content/homepage.md
+++ b/src/content/homepage.md
@@ -60,7 +60,7 @@ technologySection:
     cardText: Blockchain's success ultimately depends on its sustainability.
     links:
       - text: More details
-        url: ''
+        url:
         newTab: false
       - text: PoLW white paper
         url: https://github.com/alephium/white-paper/blob/master/polw.pdf
@@ -74,7 +74,7 @@ technologySection:
     cardText: A new programming paradigm for smart contracts and dApps.
     links:
       - text: More details
-        url: ''
+        url:
         newTab: false
       - text: Guide
         url: https://wiki.alephium.org/Smart-Contract-Guide.html
@@ -91,7 +91,7 @@ technologySection:
       Not on Alephium.
     links:
       - text: More details
-        url: ''
+        url:
         newTab: false
   numbersSection:
     title: Some numbers
@@ -220,15 +220,15 @@ footer:
     - title: Project
       links:
         - text: About us
-          url: ''
+          url:
           newTab: false
         - text: Team
-          url: ''
+          url:
           newTab: false
         - text: Contact
-          url: ''
+          url:
           newTab: false
         - text: Privacy policy
-          url: ''
+          url:
           newTab: false
 ---

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -128,7 +128,6 @@ export const pageQuery = graphql`
               cardText
               links {
                 text
-                url
                 newTab
               }
             }


### PR DESCRIPTION
so that if JS is disabled, the page will not scroll to the top when
clicking the modal links