### PR TITLE
Add broken links check when publishing to staging

### DIFF
--- a/.github/broken-link-check-config.json
+++ b/.github/broken-link-check-config.json
@@ -1,3 +1,8 @@
 {
-  "aliveStatusCodes": [200, 999]
+  "aliveStatusCodes": [200, 999],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://www.privacypolicygenerator.info"
+    }
+  ]
 }

--- a/.github/broken-link-check-config.json
+++ b/.github/broken-link-check-config.json
@@ -1,0 +1,3 @@
+{
+  "aliveStatusCodes": [200, 999]
+}

--- a/.github/workflows/publish_to_test.yaml
+++ b/.github/workflows/publish_to_test.yaml
@@ -2,7 +2,7 @@ name: Publish To Test
 
 on:
   workflow_dispatch:
-  
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.TEST_AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.TEST_AWS_SECRET_ACCESS_KEY }}
@@ -14,18 +14,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Setup node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 16.4
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.4
 
-    - name: Build website
-      run: npm install gatsby-cli && npm run build
+      - name: Build website
+        run: npm install gatsby-cli && npm run build
 
-    - name: Sync files to S3
-      run: aws s3 sync ./public/ s3://$AWS_BUCKET_NAME --acl public-read --delete --cache-control max-age=604800
+      - name: Sync files to S3
+        run: aws s3 sync ./public/ s3://$AWS_BUCKET_NAME --acl public-read --delete --cache-control max-age=604800
 
-    - name: Notify CloudFront about the changes
-      run: aws cloudfront create-invalidation --distribution-id ${AWS_DISTRIBUTION_ID} --paths "/*"
+      - name: Notify CloudFront about the changes
+        run: aws cloudfront create-invalidation --distribution-id ${AWS_DISTRIBUTION_ID} --paths "/*"
+  broken-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          folder-path: 'src/content'
+          config-file: '.github/broken-link-check-config.json'

--- a/.github/workflows/publish_to_test.yaml
+++ b/.github/workflows/publish_to_test.yaml
@@ -29,11 +29,3 @@ jobs:
 
       - name: Notify CloudFront about the changes
         run: aws cloudfront create-invalidation --distribution-id ${AWS_DISTRIBUTION_ID} --paths "/*"
-  broken-link-check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
-        with:
-          folder-path: 'src/content'
-          config-file: '.github/broken-link-check-config.json'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,16 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  broken-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          folder-path: 'src/content'
+          config-file: '.github/broken-link-check-config.json'


### PR DESCRIPTION
This PR adds a new job in our GitHub actions that scans our content and reports any broken links.

As you can [see in the test run](https://github.com/alephium/www/runs/4963517170?check_suite_focus=true), it correctly found the broken link that @VDAODAO reported here: https://github.com/AlephiumFoundation/Website/issues/9