### PR TITLE
Bring links back to technology section

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -63,7 +63,7 @@ export default styled(Modal)`
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 2;
+    z-index: 5000;
   }
 
   .content {

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -47,9 +47,10 @@ export default styled(Modal)`
     padding: var(--spacing-5) var(--spacing-8);
     box-sizing: border-box;
     position: relative;
+    margin: 0 var(--spacing-4);
 
     @media ${deviceBreakPoints.smallMobile} {
-      padding: var(--spacing-8) var(--spacing-3);
+      padding: var(--spacing-12) var(--spacing-3) var(--spacing-5);
     }
   }
 

--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -16,7 +16,7 @@ const NavigationMenu: FC<NavigationMenuProps> = ({ className }) => (
   <div className={className}>
     <div className="nav-start">
       <div className="nav-item">
-        <LinkStyled to="/">
+        <LinkStyled to="/" title="Go to homepage">
           <LogoTextStyled />
         </LinkStyled>
       </div>

--- a/src/components/PageSectionTechnology.tsx
+++ b/src/components/PageSectionTechnology.tsx
@@ -71,15 +71,13 @@ const PageSectionTechnology: FC<PageSectionTechnologyProps> = ({ className, cont
   const gradientYScale = useTransform(scrollYProgress, [start + start * 0.5, end - end * 0.1], [0, 4])
   const gradientYWidth = useTransform(scrollYProgress, [start + start * 0.5, end - end * 0.1], ['0%', '100%'])
 
-  if (!minimal) {
-    blockFlowSectionContent.links[0] = { ...blockFlowSectionContent.links[0], openModal: setIsBlockFlowModalOpen }
-    polwSectionContent.links[0] = { ...polwSectionContent.links[0], openModal: setIsPoLWModalOpen }
-    smartContractSectionContent.links[0] = {
-      ...smartContractSectionContent.links[0],
-      openModal: setIsSmartContractModalOpen
-    }
-    vmsSectionContent.links[0] = { ...vmsSectionContent.links[0], openModal: setIsVmsModalOpen }
+  blockFlowSectionContent.links[0] = { ...blockFlowSectionContent.links[0], openModal: setIsBlockFlowModalOpen }
+  polwSectionContent.links[0] = { ...polwSectionContent.links[0], openModal: setIsPoLWModalOpen }
+  smartContractSectionContent.links[0] = {
+    ...smartContractSectionContent.links[0],
+    openModal: setIsSmartContractModalOpen
   }
+  vmsSectionContent.links[0] = { ...vmsSectionContent.links[0], openModal: setIsVmsModalOpen }
 
   const columnsProps: Omit<ComponentProps<typeof Columns>, 'children'> = {
     gap: '4.5rem',
@@ -104,7 +102,7 @@ const PageSectionTechnology: FC<PageSectionTechnologyProps> = ({ className, cont
                 {...blockFlowSectionContent}
                 IconComponent={StackImage}
                 trackingName="technology-section:blockflow"
-                link={!minimal}
+                link
                 tipbox={!minimal}
               />
             </Column>
@@ -119,7 +117,7 @@ const PageSectionTechnology: FC<PageSectionTechnologyProps> = ({ className, cont
                 {...polwSectionContent}
                 IconComponent={LeafImage}
                 trackingName="technology-section:polw"
-                link={!minimal}
+                link
                 tipbox={!minimal}
               />
             </Column>
@@ -161,7 +159,7 @@ const PageSectionTechnology: FC<PageSectionTechnologyProps> = ({ className, cont
                 {...smartContractSectionContent}
                 IconComponent={StackImage}
                 trackingName="technology-section:smart-contract"
-                link={!minimal}
+                link
                 tipbox={!minimal}
               />
             </Column>
@@ -176,7 +174,7 @@ const PageSectionTechnology: FC<PageSectionTechnologyProps> = ({ className, cont
                 {...vmsSectionContent}
                 IconComponent={VmDotsImage}
                 trackingName="technology-section:vm"
-                link={!minimal}
+                link
                 tipbox={!minimal}
               />
             </Column>
@@ -208,6 +206,7 @@ const GradientContainer = styled.div`
   display: flex;
   justify-content: center;
   z-index: 4000;
+  pointer-events: none;
 `
 
 const TopGradient = styled(motion.div)`

--- a/src/components/SimpleLink.tsx
+++ b/src/components/SimpleLink.tsx
@@ -19,13 +19,16 @@ const SimpleLink: FC<SimpleLinkProps> = ({ className, children, url, newTab, tex
     }
   }
 
-  return (
+  return openModal ? (
+    <span className={className} onClick={handleOnClick} data-goatcounter-click={trackingName}>
+      {children || text}
+    </span>
+  ) : (
     <a
       className={className}
       href={url}
       target={(newTab && '_blank') || undefined}
       rel={(newTab && 'noopener noreferrer') || undefined}
-      onClick={handleOnClick}
       data-goatcounter-click={trackingName}
     >
       {children || text}

--- a/src/content/homepage.md
+++ b/src/content/homepage.md
@@ -52,17 +52,32 @@ technologySection:
       uses DAG data structure to reach consensus between different shards. This
       will allow up to 10’000 Transactions Per Second (currently more than
       400 TPS vs Bitcoins 7 TPS).
+    links:
+      - text: More details
+      - text: White paper
+        url: https://github.com/alephium/white-paper/blob/master/alephium.pdf
+        newTab: true
   smartContractSection:
     title: Programmable & Secure
     description: Alephium introduces the stateful UTXO model offering layer-1
       scalability and the same level of programmability as the account model
       used on ETH, whilst being more secure.
+    links:
+      - text: More details
+      - text: Guide
+        url: https://wiki.alephium.org/dapps/Technical-Guide-With-A-Fullnode
+        newTab: true
   polwSection:
     title: Efficiency in Energy Consumption
     description: Alephium employs "Proof of Less Work", which combines physical work
       and coin economics to dynamically adjust the work required to mine new
       blocks. Given the same network conditions, Alephium uses ~90% less energy
       compared to Bitcoin.
+    links:
+      - text: More details
+      - text: PoLW white paper
+        url: https://github.com/alephium/white-paper/blob/master/polw.pdf
+        newTab: true
   vmsSection:
     title: Its own Virtual Machine & Programming Language.
     description: The Alphred Virtual Machine solves many of the critical issues of the
@@ -72,6 +87,8 @@ technologySection:
       syntax inspired by the Rust programming language. It allows for building
       efficient and secure smart contracts easily. It's specifically designed to
       facilitate the creation of DeFi dApps!
+    links:
+      - text: More details
 numbersSection:
   title: Some numbers
   subtitle: We're passionate and committed to outstanding quality in everything

--- a/src/content/homepage.md
+++ b/src/content/homepage.md
@@ -33,7 +33,7 @@ introSection:
       description: Start building your own smart contracts, decentralized apps
         and protocols.
       link:
-        url: https://wiki.alephium.org/dapps/A-Primer-With-The-Desktop-Wallet
+        url: https://wiki.alephium.org/dapps/Language-Reference
         newTab: true
     - title: Get rewarded
       image: ../images/coins.svg

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -114,18 +114,36 @@ export const pageQuery = graphql`
             blockFlowSection {
               title
               description
+              links {
+                text
+                url
+                newTab
+              }
             }
             smartContractSection {
               title
               description
+              links {
+                text
+                url
+                newTab
+              }
             }
             polwSection {
               title
               description
+              links {
+                text
+                url
+                newTab
+              }
             }
             vmsSection {
               title
               description
+              links {
+                text
+              }
             }
           }
           numbersSection {


### PR DESCRIPTION
@mvaivre I had to change the height of the top gradient of the technology section to match the height of the section title because otherwise there is an area where the links are not clickable. See the video for an explanation. I tried to replicate the animation of the gradient as close as possible to your animation.

https://user-images.githubusercontent.com/1579899/176139724-2e932c93-f7dd-4a25-85c1-ce870e2a7a78.mp4

