### PR TITLE
Do not load hero image on every slide

### DIFF
--- a/src/components/Hero/HeroImage.tsx
+++ b/src/components/Hero/HeroImage.tsx
@@ -8,14 +8,16 @@ import HeroLightBackImage from '../../images/hero-light-back.svg'
 import HeroLightMiddleImage from '../../images/hero-light-middle.svg'
 import HeroLightFrontImage from '../../images/hero-light-front.svg'
 import { deviceBreakPoints } from '../../styles/global-style'
+import ParallaxWrapper from '../ParallaxWrapper'
 
 interface HeroImageProps {
   slide: number
   layer: 'front' | 'middle' | 'back'
+  parallaxSpeed: number
   className?: string
 }
 
-const HeroImage = ({ slide, layer, className }: HeroImageProps) => {
+const HeroImage = ({ slide, layer, parallaxSpeed, className }: HeroImageProps) => {
   const [initiallyHidden, setInitiallyHidden] = useState(true)
   const [fadeIn, setFadeIn] = useState(false)
 
@@ -43,7 +45,7 @@ const HeroImage = ({ slide, layer, className }: HeroImageProps) => {
   }, [fadeIn])
 
   return (
-    <div className={className}>
+    <ParallaxWrapper className={className} speed={parallaxSpeed}>
       <Image
         src={imageSlide1}
         className={
@@ -56,7 +58,7 @@ const HeroImage = ({ slide, layer, className }: HeroImageProps) => {
         className={layer + (slide === 0 ? ' hidden' : '')}
         alt="Layer of dark graphic background element"
       />
-    </div>
+    </ParallaxWrapper>
   )
 }
 

--- a/src/components/Hero/HeroImage.tsx
+++ b/src/components/Hero/HeroImage.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from 'react'
+import styled from 'styled-components'
+
+import HeroDarkFrontImage from '../../images/hero-dark-front.svg'
+import HeroDarkMiddleImage from '../../images/hero-dark-middle.svg'
+import HeroDarkBackImage from '../../images/hero-dark-back.svg'
+import HeroLightBackImage from '../../images/hero-light-back.svg'
+import HeroLightMiddleImage from '../../images/hero-light-middle.svg'
+import HeroLightFrontImage from '../../images/hero-light-front.svg'
+import { deviceBreakPoints } from '../../styles/global-style'
+
+interface HeroImageProps {
+  slide: number
+  layer: 'front' | 'middle' | 'back'
+  className?: string
+}
+
+const HeroImage = ({ slide, layer, className }: HeroImageProps) => {
+  const [initiallyHidden, setInitiallyHidden] = useState(true)
+  const [fadeIn, setFadeIn] = useState(false)
+
+  const imageSlide1 = {
+    front: HeroDarkFrontImage,
+    middle: HeroDarkMiddleImage,
+    back: HeroDarkBackImage
+  }[layer]
+
+  const imageSlide2 = {
+    front: HeroLightFrontImage,
+    middle: HeroLightMiddleImage,
+    back: HeroLightBackImage
+  }[layer]
+
+  useEffect(() => {
+    setInitiallyHidden(false)
+    setFadeIn(true)
+  }, [])
+
+  useEffect(() => {
+    setTimeout(() => {
+      setFadeIn(false)
+    }, 1000)
+  }, [fadeIn])
+
+  return (
+    <div className={className}>
+      <Image
+        src={imageSlide1}
+        className={
+          layer + (slide === 1 ? ' hidden' : '') + (fadeIn ? ' fade-in' : '') + (initiallyHidden ? ' hidden' : '')
+        }
+        alt="Layer of dark graphic background element"
+      />
+      <Image
+        src={imageSlide2}
+        className={layer + (slide === 0 ? ' hidden' : '')}
+        alt="Layer of dark graphic background element"
+      />
+    </div>
+  )
+}
+
+export default styled(HeroImage)`
+  position: absolute;
+  right: 0;
+  top: 0;
+  left: 0;
+  bottom: 0;
+
+  @media ${deviceBreakPoints.mobile} {
+    filter: brightness(0.5);
+  }
+`
+
+const Image = styled.img`
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  height: 100%;
+  top: 0;
+  transition: opacity 0.1s ease-in-out;
+
+  &.hidden {
+    opacity: 0;
+  }
+
+  &.front {
+    transition-duration: 0.1s;
+  }
+
+  &.middle {
+    transition-duration: 0.3s;
+  }
+
+  &.back {
+    transition-duration: 0.5s;
+  }
+
+  &.fade-in {
+    transition-duration: 0.5s;
+  }
+`

--- a/src/components/Hero/HeroSection.tsx
+++ b/src/components/Hero/HeroSection.tsx
@@ -40,24 +40,4 @@ export default styled.section`
       }
     }
   }
-
-  .hero-image-container {
-    position: absolute;
-    right: 0;
-    top: 0;
-    left: 0;
-    bottom: 0;
-
-    .hero-image {
-      position: absolute;
-      right: 0;
-      bottom: 0;
-      height: 100%;
-      top: 0;
-    }
-
-    @media ${deviceBreakPoints.mobile} {
-      filter: brightness(0.5);
-    }
-  }
 `

--- a/src/components/PageSectionHero.tsx
+++ b/src/components/PageSectionHero.tsx
@@ -49,9 +49,9 @@ const PageSectionHero: FC<PageSectionHeroProps> = ({ className, content }) => {
     <ThemeProvider theme={darkTheme}>
       <HeroSlider heroElementRef={innerRef} onSwipe={onSwipe}>
         <HeroSection className={className} ref={innerRef}>
-          <HeroImage layer="back" slide={slide} />
-          <HeroImage layer="middle" slide={slide} />
-          <HeroImage layer="front" slide={slide} />
+          <HeroImage layer="back" slide={slide} parallaxSpeed={12} />
+          <HeroImage layer="middle" slide={slide} parallaxSpeed={8} />
+          <HeroImage layer="front" slide={slide} parallaxSpeed={2} />
           <HeroPageSectionContainer>
             <div className="navigation-menu-wrapper">
               <NavigationMenu />

--- a/src/components/PageSectionHero.tsx
+++ b/src/components/PageSectionHero.tsx
@@ -12,17 +12,9 @@ import HeroSection from './Hero/HeroSection'
 import HeroContentWrapper from './Hero/HeroContentWrapper'
 import HeroPageSectionContainer from './Hero/HeroPageSectionContainer'
 
-import HeroDarkFrontImage from '../images/hero-dark-front.svg'
-import HeroDarkMiddleImage from '../images/hero-dark-middle.svg'
-import HeroDarkBackImage from '../images/hero-dark-back.svg'
-import HeroLightBackImage from '../images/hero-light-back.svg'
-import HeroLightMiddleImage from '../images/hero-light-middle.svg'
-import HeroLightFrontImage from '../images/hero-light-front.svg'
-
 import Arrow from '../images/svgs/arrow-right.svg'
-import ParallaxWrapper from './ParallaxWrapper'
-import { AnimatePresence, motion } from 'framer-motion'
 import AlephiumLogo from './AlephiumLogo'
+import HeroImage from './Hero/HeroImage'
 
 export interface PageSectionHeroContentType {
   dark: {
@@ -57,34 +49,9 @@ const PageSectionHero: FC<PageSectionHeroProps> = ({ className, content }) => {
     <ThemeProvider theme={darkTheme}>
       <HeroSlider heroElementRef={innerRef} onSwipe={onSwipe}>
         <HeroSection className={className} ref={innerRef}>
-          <AnimatePresence>
-            {slide === 0 ? (
-              <motion.div animate={{ opacity: 1 }} exit={{ opacity: 0 }} key={0}>
-                <ParallaxWrapper className="hero-image-container" speed={-8}>
-                  <img src={HeroDarkBackImage} alt="Hero dark back" className="hero-image" />
-                </ParallaxWrapper>
-                <ParallaxWrapper className="hero-image-container" speed={8}>
-                  <img src={HeroDarkMiddleImage} className="hero-image" alt="Hero dark front" />
-                </ParallaxWrapper>
-                <ParallaxWrapper className="hero-image-container" speed={2}>
-                  <img src={HeroDarkFrontImage} className="hero-image" alt="Hero dark front" />
-                </ParallaxWrapper>
-              </motion.div>
-            ) : (
-              <motion.div animate={{ opacity: 1 }} exit={{ opacity: 0 }} key={1}>
-                <ParallaxWrapper className="hero-image-container" speed={12}>
-                  <img src={HeroLightBackImage} alt="Hero dark back" className="hero-image" />
-                </ParallaxWrapper>
-                <ParallaxWrapper className="hero-image-container" speed={8}>
-                  <img src={HeroLightMiddleImage} className="hero-image" alt="Hero dark front" />
-                </ParallaxWrapper>
-                <ParallaxWrapper className="hero-image-container" speed={2}>
-                  <img src={HeroLightFrontImage} className="hero-image" alt="Hero dark front" />
-                </ParallaxWrapper>
-              </motion.div>
-            )}
-          </AnimatePresence>
-
+          <HeroImage layer="back" slide={slide} />
+          <HeroImage layer="middle" slide={slide} />
+          <HeroImage layer="front" slide={slide} />
           <HeroPageSectionContainer>
             <div className="navigation-menu-wrapper">
               <NavigationMenu />


### PR DESCRIPTION
I removed framer motion animations and replaced them with a simple opacity `transition`.

@mvaivre feel free to play around with the following values to adjust the transition speed of the different layers:

```css
  &.front {
    transition-duration: 0.1s;
  }

  &.middle {
    transition-duration: 0.3s;
  }

  &.back {
    transition-duration: 0.5s;
  }
```

I also implemented an initial fade-in of the image, ~~not sure it affects our Lighthouse score, testing now...~~ all good, nothing changed:

<img width="559" alt="image" src="https://user-images.githubusercontent.com/1579899/178476464-fd07192a-c23b-4935-b688-7f8ecaa55570.png">

Here's a preview: https://www2.alephium.org