### PR TITLE
Open privacy modal with URL param

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useEffect, useState } from 'react'
 import styled, { useTheme } from 'styled-components'
 
 import { deviceBreakPoints } from '../styles/global-style'
@@ -21,11 +21,12 @@ export interface FooterContentType {
 }
 
 interface FooterProps {
-  className?: string
   content: FooterContentType
+  openPrivacyPolicyModal?: boolean
+  className?: string
 }
 
-const Footer: FC<FooterProps> = ({ className, content }) => {
+const Footer: FC<FooterProps> = ({ className, content, openPrivacyPolicyModal }) => {
   const [isTeamModalOpen, setIsTeamModalOpen] = useState(false)
   const [isContactModalOpen, setIsContactModalOpen] = useState(false)
   const [isPrivacyPolicyModalOpen, setIsPrivacyPolicyModalOpen] = useState(false)
@@ -33,6 +34,11 @@ const Footer: FC<FooterProps> = ({ className, content }) => {
   columnsContent[2].links[0] = { ...columnsContent[2].links[0], openModal: setIsTeamModalOpen }
   columnsContent[2].links[2] = { ...columnsContent[2].links[2], openModal: setIsContactModalOpen }
   columnsContent[2].links[3] = { ...columnsContent[2].links[3], openModal: setIsPrivacyPolicyModalOpen }
+
+  useEffect(() => {
+    if (openPrivacyPolicyModal) setIsPrivacyPolicyModalOpen(true)
+  }, [openPrivacyPolicyModal])
+
   return (
     <div className={className}>
       <PageSectionContainerStyled>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -40,6 +40,8 @@ interface IndexPageProps extends PageProps {
 
 const IndexPage = (props: IndexPageProps) => {
   const pageContent = props.data.homepage.nodes[0].frontmatter
+  const params = new URLSearchParams(props.location.search)
+  const openPrivacyPolicyModal = params.get('privacy') !== null
 
   return (
     <>
@@ -67,7 +69,7 @@ const IndexPage = (props: IndexPageProps) => {
           <PageSectionShop content={pageContent.shopSection} />
           <PageSectionFollowUs content={pageContent.followUsSection} />
           <PageSectionSunOverTheMountains />
-          <Footer content={pageContent.footer} />
+          <Footer content={pageContent.footer} openPrivacyPolicyModal={openPrivacyPolicyModal} />
         </ThemeProvider>
       </main>
     </>


### PR DESCRIPTION
Requested by @h0ngcha0:

> To publish the extension wallet on Chrome we need a link to our privacy policy. We do have the privacy policy available on [alephium.org](http://alephium.org/) but seems that we can't link to it, is there a way to expose a link to it?

to which I replied:

> There’s no way implemented currently. I can work on either:
> - Creating a dedicated page at [alephium.org/privacy](http://alephium.org/privacy)
> - Implement some JS that will listen for a parameter in the URL (like [alephium.org/?privacy](http://alephium.org/?privacy)) and will force the modal to open

Since the second option is faster to implement and doesn't require any stylistic decisions, I went ahead with it.