### PR TITLE
make discord invite link point to #verification channel

### DIFF
--- a/src/content/homepage.md
+++ b/src/content/homepage.md
@@ -323,7 +323,7 @@ followUsSection:
     technology? Come learn and build!
   socialMediaLinks:
     - name: Discord
-      url: https://discord.gg/JErgRBfRSB
+      url: https://discord.gg/XsGpZ5VDTM
     - name: Telegram
       url: https://t.me/alephiumgroup
     - name: Twitter


### PR DESCRIPTION
While documenting the settings in Discord, i found an issue that, if resolved with this small fix, will greatly enhance on-boarding for users joining the Guild via the permanent link: `https://alephium.org/discord`. 

The current link (https://discord.gg/JErgRBfRSB) points to the channel "#rules" where we previously had the verification process. This channel is no longer visible to `@everyone` which makes discord looks confusing to newcomers. (The rules are always displayed explicitly to newcomers through the discord interface during on-boarding as shown in the image bellow)
![image](https://user-images.githubusercontent.com/3484593/224058579-aa6001f6-fa27-4e12-817b-a84f326e58e3.png)
 
By merging this change, nothing happens to existing link (`https://discord.gg/JErgRBfRSB`). That one will remain active and no breakage will happen. But future users joining via the permanent link will have a much smoother entry to the guild as they will automatically land in the verification channel and everything will look a lot better.