### PR TITLE
feat: Allow AI crawlers in robots.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ public
 .DS_Store
 /src/gatsby-types.d.ts
 .env
+.claude/

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -5,19 +5,31 @@ Disallow: /onramp-callback
 Disallow: /grant-application-callback
 
 User-agent: GPTBot
-Allow: /
+Disallow: /banxa-callback
+Disallow: /onramp-callback
+Disallow: /grant-application-callback
 
 User-agent: ChatGPT-User
-Allow: /
+Disallow: /banxa-callback
+Disallow: /onramp-callback
+Disallow: /grant-application-callback
 
 User-agent: ClaudeBot
-Allow: /
+Disallow: /banxa-callback
+Disallow: /onramp-callback
+Disallow: /grant-application-callback
 
 User-agent: anthropic-ai
-Allow: /
+Disallow: /banxa-callback
+Disallow: /onramp-callback
+Disallow: /grant-application-callback
 
 User-agent: PerplexityBot
-Allow: /
+Disallow: /banxa-callback
+Disallow: /onramp-callback
+Disallow: /grant-application-callback
 
 User-agent: Applebot
-Allow: /
+Disallow: /banxa-callback
+Disallow: /onramp-callback
+Disallow: /grant-application-callback

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,11 +1,23 @@
 User-agent: *
 Disallow: /cmc-application-proof.txt
-
-User-agent: *
 Disallow: /banxa-callback
-
-User-agent: *
 Disallow: /onramp-callback
-
-User-agent: *
 Disallow: /grant-application-callback
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Applebot
+Allow: /


### PR DESCRIPTION
 ## What
  Explicitly allow AI crawlers in robots.txt and consolidate duplicate User-agent rules.

## Why
  Some AI crawlers require explicit Allow rules to index content.

## Changes
  - `robots.txt`: add explicit Allow for GPTBot, ChatGPT-User, ClaudeBot,
    anthropic-ai, PerplexityBot, Applebot
  - Consolidate four separate `User-agent: *` blocks into one

## Verification
  - [ ] https://alephium.org/robots.txt shows the new rules after deploy